### PR TITLE
refactor: add single app build scripts for deployments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           expo-token: ${{ secrets.EXPO_TOKEN }}
 
       - name: 👷 Build packages for mobile
-        run: pnpm run -w build:mobile"
+        run: pnpm run -w build:mobile
 
       - name: 🚀 Build mobile
         working-directory: apps/mobile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,8 @@ jobs:
         with:
           expo-token: ${{ secrets.EXPO_TOKEN }}
 
-      - name: 👷 Build packages
-        run: pnpm run -w build
+      - name: 👷 Build packages for mobile
+        run: pnpm run -w build:mobile"
 
       - name: 🚀 Build mobile
         working-directory: apps/mobile

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ Because this monorepo uses [Turborepo](https://turborepo.org/), you don't need t
 - `$ pnpm test` - Run all tests for packages with Jest tests.
 - `$ pnpm build` - Build all **apps** and **packages** for production or to publish them on npm.
 
+When deploying a single app to production, you only need to build a specific app with all dependencies. This monorepo uses a simple npm script convention of `build:<app-name>` to keep this process simple. Under the hood, it uses [Turborepo's workspace filtering](https://turbo.build/repo/docs/core-concepts/monorepos/filtering), defined as an npm script in the root [**package.json**](./package.json).
+
+- `$ pnpm build:mobile` - Build **apps/mobile** and all **packages** used in mobile.
+- `$ pnpm build:web` - Build **apps/web** and all **packages** used in web.
+
 ### Switching to yarn or npm
 
 You can use yarn or npm with this monorepo as well. If you want to use one of these package managers, instead of pnpm, all you have to do is:

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -12,7 +12,7 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "eas-build-pre-install": "npm install --global pnpm@7.x",
-    "eas-build-post-install": "pnpm run -w build"
+    "eas-build-post-install": "pnpm run -w build:mobile"
   },
   "dependencies": {
     "@acme/feature-home": "*",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "private": true,
   "name": "@acme/monorepo",
   "scripts": {
+    "dev": "turbo dev",
     "lint": "turbo lint",
     "test": "turbo test",
     "build": "turbo build",
-    "dev": "turbo dev"
+    "build:mobile": "turbo build --filter=\"...{./apps/mobile}\"",
+    "build:web": "turbo build --filter=\"...{./apps/web}\""
   },
   "devDependencies": {
     "turbo": "^1.5.4",


### PR DESCRIPTION
### Linked issue
See docs

You can use these scripts in EAS or Vercel to only build the required workspaces, and deploy to production.