### PR TITLE
refactor(mobile): use `"pnpm": "<version>"` in `eas.json`

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -4,6 +4,7 @@
   },
   "build": {
     "monorepo": {
+      "pnpm": "8.12.0",
       "cache": {
         "key": "turbo",
         "paths": [

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -11,7 +11,6 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "eas-build-pre-install": "npm install --global pnpm@7.x",
     "eas-build-post-install": "pnpm run -w build:mobile"
   },
   "dependencies": {


### PR DESCRIPTION
### Linked issue
We can do this better, instead of installing through an EAS build npm script.