### PR TITLE
refactor: drop `@types/react-native`

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -30,7 +30,6 @@
     "@babel/core": "^7.19.3",
     "@types/react": "~18.2.14",
     "@types/react-dom": "~18.0.11",
-    "@types/react-native": "~0.70.6",
     "babel-preset-expo": "~9.5.0"
   },
   "eslintConfig": {

--- a/packages/feature-home/package.json
+++ b/packages/feature-home/package.json
@@ -27,7 +27,6 @@
     "@tsconfig/recommended": "^1.0.1",
     "@types/jest": "^26.0.24",
     "@types/react": "~18.0.25",
-    "@types/react-native": "~0.70.6",
     "babel-preset-expo": "~9.5.0",
     "jest": "^29.4.3",
     "jest-expo": "^49.0.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -24,7 +24,6 @@
     "@tsconfig/recommended": "^1.0.1",
     "@types/jest": "^26.0.24",
     "@types/react": "~18.0.25",
-    "@types/react-native": "~0.70.6",
     "babel-preset-expo": "~9.5.0",
     "jest": "^29.4.3",
     "jest-expo": "^49.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,6 @@ importers:
       '@types/react-dom':
         specifier: ~18.0.11
         version: 18.0.11
-      '@types/react-native':
-        specifier: ~0.70.6
-        version: 0.70.6
       babel-preset-expo:
         specifier: ~9.5.0
         version: 9.5.0(@babel/core@7.20.2)
@@ -137,9 +134,6 @@ importers:
       '@types/react':
         specifier: ~18.0.25
         version: 18.0.25
-      '@types/react-native':
-        specifier: ~0.70.6
-        version: 0.70.6
       babel-preset-expo:
         specifier: ~9.5.0
         version: 9.5.0(@babel/core@7.20.2)
@@ -183,9 +177,6 @@ importers:
       '@types/react':
         specifier: ~18.0.25
         version: 18.0.25
-      '@types/react-native':
-        specifier: ~0.70.6
-        version: 0.70.6
       babel-preset-expo:
         specifier: ~9.5.0
         version: 9.5.0(@babel/core@7.20.2)
@@ -3397,12 +3388,6 @@ packages:
 
   /@types/react-dom@18.0.11:
     resolution: {integrity: sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==}
-    dependencies:
-      '@types/react': 18.0.28
-    dev: true
-
-  /@types/react-native@0.70.6:
-    resolution: {integrity: sha512-ynQ2jj0km9d7dbnyKqVdQ6Nti7VQ8SLTA/KKkkS5+FnvGyvij2AOo1/xnkBR/jnSNXuzrvGVzw2n0VWfppmfKw==}
     dependencies:
       '@types/react': 18.0.28
     dev: true


### PR DESCRIPTION
### Linked issue
This is now shipped with `react-native` itself.