### PR TITLE
chore: test running hermes parser on macos and linux to see if macos fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,11 @@ env:
 
 jobs:
   packages:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos, ubuntu]
     steps:
       - name: 🏗 Setup repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This might indicate that the hermes binary is non-functional on Linux, which is a problem.
