### PR TITLE
refactor: do not run `build` when running the `test` command

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,6 @@
       "outputs": []
     },
     "test": {
-      "dependsOn": ["build"],
       "inputs": ["**/*.{ts,tsx,js,jsx}"]
     },
     "build": {


### PR DESCRIPTION
Within this repository, we now expose the raw typescript to Metro directly. This has a few benefits, namely that React Compiler is also applied to all workspaces within this monorepo. It also doesnt require us to run `build` before running `test`.

The downside of this is that when using custom TypeScript extensions, all apps consuming this code needs to know about it. Otherwise Metro doesnt know how to transform the code. But, we arent using this at all.